### PR TITLE
Add checking of protocol module filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Add checking of [protocol](https://elixir-lang.org/getting-started/protocols.html) module filenames by [@liskin](https://github.com/liskin). [#2](https://github.com/mirego/credo_filename_consistency/pull/2)
+
 ## [0.2.0] - 2019-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Add support for [umbrella projects](https://elixir-lang.org/getting-started/mix-otp/dependencies-and-umbrella-projects.html#umbrella-projects<Paste>) by [@liskin](https://github.com/liskin). [#1](https://github.com/mirego/credo_filename_consistency/pull/1)
+- Add support for [umbrella projects](https://elixir-lang.org/getting-started/mix-otp/dependencies-and-umbrella-projects.html#umbrella-projects) by [@liskin](https://github.com/liskin). [#1](https://github.com/mirego/credo_filename_consistency/pull/1)

--- a/lib/credo_filename_consistency/check/consistency/filename_consistency.ex
+++ b/lib/credo_filename_consistency/check/consistency/filename_consistency.ex
@@ -79,7 +79,9 @@ defmodule CredoFilenameConsistency.Check.Consistency.FilenameConsistency do
     Enum.reduce(statements, [], &process_root_statement/2)
   end
 
-  defp root_modules({:defmodule, _, _} = statement) do
+  defp root_modules({def_, _, _} = statement)
+       when def_ == :defmodule
+       when def_ == :defprotocol do
     process_root_statement(statement, [])
   end
 
@@ -90,6 +92,11 @@ defmodule CredoFilenameConsistency.Check.Consistency.FilenameConsistency do
     line_no = Keyword.get(opts, :line)
 
     [{name, line_no} | acc]
+  end
+
+  defp process_root_statement({:defprotocol, opts, args}, acc) do
+    # Credo.Code.Module doesn't understand defprotocol, work around it
+    process_root_statement({:defmodule, opts, args}, acc)
   end
 
   defp process_root_statement(_, acc), do: acc

--- a/lib/credo_filename_consistency/check/consistency/filename_consistency.ex
+++ b/lib/credo_filename_consistency/check/consistency/filename_consistency.ex
@@ -76,30 +76,22 @@ defmodule CredoFilenameConsistency.Check.Consistency.FilenameConsistency do
   end
 
   defp root_modules({:__block__, _, statements}) do
-    Enum.reduce(statements, [], &process_root_statement/2)
+    Enum.flat_map(statements, &root_modules/1)
   end
 
-  defp root_modules({def_, _, _} = statement)
-       when def_ == :defmodule
-       when def_ == :defprotocol do
-    process_root_statement(statement, [])
-  end
-
-  defp root_modules(_), do: []
-
-  defp process_root_statement({:defmodule, opts, _} = module, acc) do
+  defp root_modules({:defmodule, opts, _} = module) do
     name = Code.Module.name(module)
     line_no = Keyword.get(opts, :line)
 
-    [{name, line_no} | acc]
+    [{name, line_no}]
   end
 
-  defp process_root_statement({:defprotocol, opts, args}, acc) do
+  defp root_modules({:defprotocol, opts, args}) do
     # Credo.Code.Module doesn't understand defprotocol, work around it
-    process_root_statement({:defmodule, opts, args}, acc)
+    root_modules({:defmodule, opts, args})
   end
 
-  defp process_root_statement(_, acc), do: acc
+  defp root_modules(_), do: []
 
   defp issue_for(issue_meta, line_no, %{filename: filename}, expected_filenames, full_name) do
     format_issue(

--- a/test/credo_filename_consistency/check/consistency/filename_consistency_test.exs
+++ b/test/credo_filename_consistency/check/consistency/filename_consistency_test.exs
@@ -85,6 +85,19 @@ defmodule CredoFilenameConsistency.Check.Consistency.FilenameConsistencyTest do
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report violation for file with single protocol and implementations of it" do
+    """
+    defprotocol Foo.Bar do
+    end
+    defimpl Foo.Bar, for: List do
+    end
+    defimpl Foo.Bar, for: Map do
+    end
+    """
+    |> to_source_file("lib/foo/bar.ex")
+    |> refute_issues(@described_check)
+  end
+
   test "it should NOT report violation for nested module in umbrella app" do
     """
     defmodule Foo.Bar do
@@ -131,6 +144,32 @@ defmodule CredoFilenameConsistency.Check.Consistency.FilenameConsistencyTest do
     end
     """
     |> to_source_file("lib/foo_web/bar.ex")
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report a violation for wrong module name (with implementations for it)" do
+    """
+    defmodule Foo.Baz do
+    end
+    defimpl Jason.Encoder, for: Foo.Baz do
+    end
+    defimpl Poison.Encoder, for: Foo.Baz do
+    end
+    """
+    |> to_source_file("lib/foo/bar.ex")
+    |> assert_issue(@described_check)
+  end
+
+  test "it should report a violation for wrong protocol name (with implementations of it)" do
+    """
+    defprotocol Foo.Baz do
+    end
+    defimpl Foo.Baz, for: List do
+    end
+    defimpl Foo.Baz, for: Map do
+    end
+    """
+    |> to_source_file("lib/foo/bar.ex")
     |> assert_issue(@described_check)
   end
 end

--- a/test/credo_filename_consistency/check/consistency/filename_consistency_test.exs
+++ b/test/credo_filename_consistency/check/consistency/filename_consistency_test.exs
@@ -72,6 +72,22 @@ defmodule CredoFilenameConsistency.Check.Consistency.FilenameConsistencyTest do
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report violation for file with multiple modules defined in weird way" do
+    """
+    defmodule Foo.QueryException do
+    end
+    (
+    defmodule Foo.ReportException do
+    end
+    ;
+    defmodule Foo.OutputException do
+    end
+    )
+    """
+    |> to_source_file("lib/foo/exceptions.ex")
+    |> refute_issues(@described_check)
+  end
+
   test "it should NOT report violation for file with single module and implementations for it" do
     """
     defmodule Foo.Bar do


### PR DESCRIPTION
Protocol modules deserve to be properly named, too. :-)

The implementation is a bit of a hack as Credo.Code.Module doesn't
support protocols and neither is there any Credo.Code.Protocol (in fact
there's not a single mention of defprotocol in the entire Credo
codebase). I'll consider sending a PR to credo later.